### PR TITLE
[feat] Chef shoots projectiles at mice in range at given intervals

### DIFF
--- a/Assets/Prefabs/Chef.prefab
+++ b/Assets/Prefabs/Chef.prefab
@@ -98,3 +98,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   range: 6
+  Projectile: {fileID: 6520961873034949681, guid: 47b76cd4b51073742b3434446e6350ae, type: 3}
+  cooldown: 1

--- a/Assets/Prefabs/Mouse.prefab
+++ b/Assets/Prefabs/Mouse.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 5123174453720965023}
   - component: {fileID: 4181688277928253522}
   - component: {fileID: 5508047057535583039}
+  - component: {fileID: 5400240932857522934}
   m_Layer: 0
   m_Name: Mouse
   m_TagString: Mouse
@@ -111,3 +112,38 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f35fe906f60b4a449bc1dc98786ca2c8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!58 &5400240932857522934
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7551363394588081444}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5

--- a/Assets/Scripts/Chef.cs
+++ b/Assets/Scripts/Chef.cs
@@ -5,12 +5,16 @@ using UnityEngine;
 public class Chef : MonoBehaviour
 {
     [SerializeField] private float range; // range at which chef can attack mice
+    [SerializeField] private GameObject Projectile; // projectile for chef to shoot
+    [SerializeField] private float cooldown; // time in between chef shooting (seconds)
+    private float cooldownTimer; // timer for cooldown in between shots
 
     void Update()
     {
         GameObject furthestMouse = GetFurthestMouseInRange();
         if (furthestMouse == null) return;
         Rotate(furthestMouse);
+        Shoot();
     }
 
 
@@ -58,5 +62,15 @@ public class Chef : MonoBehaviour
         }
 
         return miceInRange;
+    }
+
+    /// <summary> Shoot projectile in direction facing </summary>
+    /// <remarks>Maintained by: Ben Brixton </remarks>
+    private void Shoot()
+    {
+        cooldownTimer -= Time.deltaTime;
+        if (cooldownTimer > 0) return;
+        cooldownTimer = cooldown;
+        Instantiate(Projectile, transform.position, transform.rotation);
     }
 }


### PR DESCRIPTION
- New projectile prefab using temporary sprite. It moves forwards at given speed. 
- Added a shooting function to the chef prefab, where it shoots at a given interval (instantiates projectile prefab). Only shoots when a mouse is in range. 
- If the projectile hits a collider or after a given time period it is destroyed. 
- Added 2D colliders to projectile and mouse, as well as adding 2D rigid body to the projectile so that the colliders work.

https://github.com/Project-Pixel-UoS/Chef-s-last-stand/assets/109489475/2fa2933a-5fbd-4929-8bc4-fe63807b5999

