### PR TITLE
Improved AbilityBuff script, fixed chef colliders/buff scripts

### DIFF
--- a/Assets/Prefabs/Chef Entremetier.prefab
+++ b/Assets/Prefabs/Chef Entremetier.prefab
@@ -142,6 +142,7 @@ GameObject:
   - component: {fileID: 7533226973392138995}
   - component: {fileID: -3343250522032395345}
   - component: {fileID: 1214436624015060238}
+  - component: {fileID: 1925694442024242584}
   m_Layer: 0
   m_Name: Chef Entremetier
   m_TagString: Untagged
@@ -266,6 +267,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chefCost: 0
   rangeCost: 5
+--- !u!114 &1925694442024242584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &1441932722712167455
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Chef Head.prefab
+++ b/Assets/Prefabs/Chef Head.prefab
@@ -95,7 +95,6 @@ GameObject:
   - component: {fileID: 647212506296903406}
   - component: {fileID: -5508901516222845255}
   - component: {fileID: 7016424228477295924}
-  - component: {fileID: -5843223008570000811}
   - component: {fileID: -5073770246374414763}
   - component: {fileID: -458673801847131121}
   - component: {fileID: 5659145071796658612}
@@ -152,41 +151,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   radius: 3
   rangeObject: {fileID: 6208724048470825412}
---- !u!58 &-5843223008570000811
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1109480781222891229}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 3
 --- !u!114 &-5073770246374414763
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Chef Potager.prefab
+++ b/Assets/Prefabs/Chef Potager.prefab
@@ -98,6 +98,7 @@ GameObject:
   - component: {fileID: 8053452737509301959}
   - component: {fileID: -2807020189367368203}
   - component: {fileID: 8417773937103734731}
+  - component: {fileID: 6163579080064339587}
   m_Layer: 0
   m_Name: Chef Potager
   m_TagString: Untagged
@@ -222,6 +223,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chefCost: 5
   rangeCost: 5
+--- !u!114 &6163579080064339587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &4054988461792321345
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Chef Waiter.prefab
+++ b/Assets/Prefabs/Chef Waiter.prefab
@@ -97,6 +97,7 @@ GameObject:
   - component: {fileID: 8053452737509301959}
   - component: {fileID: 6049553212818791163}
   - component: {fileID: 3091158959010883618}
+  - component: {fileID: 6252839155425228636}
   m_Layer: 0
   m_Name: Chef Waiter
   m_TagString: Untagged
@@ -208,6 +209,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &6252839155425228636
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &2195827266284736907
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 0.prefab
+++ b/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 0.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 6007071514904664862}
   - component: {fileID: -1469115511128794750}
   - component: {fileID: 8854314696486517693}
+  - component: {fileID: 8744337260076530441}
   m_Layer: 0
   m_Name: Chef Grillardin 0
   m_TagString: Grillardin
@@ -157,6 +158,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chefCost: 100
   rangeCost: 20
+--- !u!114 &8744337260076530441
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &3409814503728593753
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 1.prefab
+++ b/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 1.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 6007071514904664862}
   - component: {fileID: -1469115511128794750}
   - component: {fileID: 926503234997353360}
+  - component: {fileID: 4552852575602547339}
   m_Layer: 0
   m_Name: Chef Grillardin 1
   m_TagString: Grillardin
@@ -157,6 +158,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chefCost: 20
   rangeCost: 20
+--- !u!114 &4552852575602547339
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &3409814503728593753
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 2.prefab
+++ b/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 2.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 6007071514904664862}
   - component: {fileID: -1469115511128794750}
   - component: {fileID: 65973855541624813}
+  - component: {fileID: 1116349749984029797}
   m_Layer: 0
   m_Name: Chef Grillardin 2
   m_TagString: Grillardin
@@ -157,6 +158,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chefCost: 40
   rangeCost: 20
+--- !u!114 &1116349749984029797
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &3409814503728593753
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 3.prefab
+++ b/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 3.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 6007071514904664862}
   - component: {fileID: -1469115511128794750}
   - component: {fileID: -3093406301763355756}
+  - component: {fileID: 2203918469466225905}
   m_Layer: 0
   m_Name: Chef Grillardin 3
   m_TagString: Grillardin
@@ -157,6 +158,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chefCost: 60
   rangeCost: 20
+--- !u!114 &2203918469466225905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &3409814503728593753
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 4.prefab
+++ b/Assets/Prefabs/Grillardin/Chef/Chef Grillardin 4.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 6007071514904664862}
   - component: {fileID: -1469115511128794750}
   - component: {fileID: -2270968725706419191}
+  - component: {fileID: 6029396960229104904}
   m_Layer: 0
   m_Name: Chef Grillardin 4
   m_TagString: Grillardin
@@ -157,6 +158,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   chefCost: 100
   rangeCost: 20
+--- !u!114 &6029396960229104904
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &3409814503728593753
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 0.prefab
+++ b/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 0.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 647212506296903406}
   - component: {fileID: -9203637450718709653}
   - component: {fileID: -1970727718610732877}
-  - component: {fileID: 5461096997308423307}
   - component: {fileID: 7887215541740292448}
   - component: {fileID: 2325135678370490676}
+  - component: {fileID: -2098903044050691176}
+  - component: {fileID: 2893290450505863667}
   m_Layer: 0
   m_Name: Chef Prep Cook 0
   m_TagString: PrepCook
@@ -67,7 +68,48 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   radius: 2
   rangeObject: {fileID: 8700967512257991476}
---- !u!61 &5461096997308423307
+--- !u!114 &7887215541740292448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2325135678370490676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chefCost: 40
+  rangeCost: 10
+--- !u!114 &-2098903044050691176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
+--- !u!61 &2893290450505863667
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -99,45 +141,19 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.022040546, y: -0.05142811}
+  m_Offset: {x: -0.002350688, y: 0.082272634}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.25, y: 1.25}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.9563326, y: 1.3245025}
+  m_Size: {x: 1.0611169, y: 0.56748104}
   m_EdgeRadius: 0
---- !u!114 &7887215541740292448
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1109480781222891229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &2325135678370490676
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1109480781222891229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  chefCost: 40
-  rangeCost: 10
 --- !u!1 &4281193363392056481
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 1.prefab
+++ b/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 1.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 647212506296903406}
   - component: {fileID: -9203637450718709653}
   - component: {fileID: -1970727718610732877}
-  - component: {fileID: 5461096997308423307}
   - component: {fileID: 7887215541740292448}
   - component: {fileID: 2185342722064317430}
+  - component: {fileID: 1138738969103742989}
+  - component: {fileID: 4897977139963022288}
   m_Layer: 0
   m_Name: Chef Prep Cook 1
   m_TagString: PrepCook
@@ -67,7 +68,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   radius: 2
   rangeObject: {fileID: 8700967512257991476}
---- !u!61 &5461096997308423307
+--- !u!114 &7887215541740292448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2185342722064317430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chefCost: 10
+  rangeCost: 10
+--- !u!61 &1138738969103742989
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -99,20 +126,20 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.022040546, y: -0.05142811}
+  m_Offset: {x: -0.002350688, y: 0.082272634}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.25, y: 1.25}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.9563326, y: 1.3245025}
+  m_Size: {x: 1.0611169, y: 0.56748104}
   m_EdgeRadius: 0
---- !u!114 &7887215541740292448
+--- !u!114 &4897977139963022288
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -121,23 +148,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 1109480781222891229}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &2185342722064317430
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1109480781222891229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  chefCost: 10
-  rangeCost: 10
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &3259608340144216887
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 2.prefab
+++ b/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 2.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 647212506296903406}
   - component: {fileID: -9203637450718709653}
   - component: {fileID: -1970727718610732877}
-  - component: {fileID: 5461096997308423307}
   - component: {fileID: 7887215541740292448}
   - component: {fileID: 3256497228894662022}
+  - component: {fileID: 4727502684924421229}
+  - component: {fileID: 2431992648814847000}
   m_Layer: 0
   m_Name: Chef Prep Cook 2
   m_TagString: PrepCook
@@ -67,7 +68,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   radius: 2
   rangeObject: {fileID: 8700967512257991476}
---- !u!61 &5461096997308423307
+--- !u!114 &7887215541740292448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3256497228894662022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chefCost: 30
+  rangeCost: 10
+--- !u!61 &4727502684924421229
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -99,20 +126,20 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.022040546, y: -0.05142811}
+  m_Offset: {x: -0.002350688, y: 0.082272634}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.25, y: 1.25}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.9563326, y: 1.3245025}
+  m_Size: {x: 1.0611169, y: 0.56748104}
   m_EdgeRadius: 0
---- !u!114 &7887215541740292448
+--- !u!114 &2431992648814847000
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -121,23 +148,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 1109480781222891229}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &3256497228894662022
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1109480781222891229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  chefCost: 30
-  rangeCost: 10
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &4281193363392056481
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 3.prefab
+++ b/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 3.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 647212506296903406}
   - component: {fileID: -9203637450718709653}
   - component: {fileID: -1970727718610732877}
-  - component: {fileID: 5461096997308423307}
   - component: {fileID: 7887215541740292448}
   - component: {fileID: -5971118695333875322}
+  - component: {fileID: 1168377295816183889}
+  - component: {fileID: 1642028846877242973}
   m_Layer: 0
   m_Name: Chef Prep Cook 3
   m_TagString: PrepCook
@@ -67,7 +68,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   radius: 2
   rangeObject: {fileID: 8700967512257991476}
---- !u!61 &5461096997308423307
+--- !u!114 &7887215541740292448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &-5971118695333875322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chefCost: 35
+  rangeCost: 10
+--- !u!61 &1168377295816183889
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -99,20 +126,20 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.022040546, y: -0.05142811}
+  m_Offset: {x: -0.002350688, y: 0.082272634}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.25, y: 1.25}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.9563326, y: 1.3245025}
+  m_Size: {x: 1.0611169, y: 0.56748104}
   m_EdgeRadius: 0
---- !u!114 &7887215541740292448
+--- !u!114 &1642028846877242973
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -121,23 +148,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 1109480781222891229}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &-5971118695333875322
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1109480781222891229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  chefCost: 35
-  rangeCost: 10
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &4281193363392056481
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 4.prefab
+++ b/Assets/Prefabs/Prep Cook/Chef/Chef Prep Cook 4.prefab
@@ -11,9 +11,10 @@ GameObject:
   - component: {fileID: 647212506296903406}
   - component: {fileID: -9203637450718709653}
   - component: {fileID: -1970727718610732877}
-  - component: {fileID: 5461096997308423307}
   - component: {fileID: 7887215541740292448}
   - component: {fileID: -3754631054435307852}
+  - component: {fileID: 1966830663837495173}
+  - component: {fileID: 5236896937607921620}
   m_Layer: 0
   m_Name: Chef Prep Cook 4
   m_TagString: PrepCook
@@ -67,7 +68,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   radius: 2
   rangeObject: {fileID: 8700967512257991476}
---- !u!61 &5461096997308423307
+--- !u!114 &7887215541740292448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &-3754631054435307852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1109480781222891229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chefCost: 40
+  rangeCost: 0
+--- !u!61 &1966830663837495173
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -99,20 +126,20 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.022040546, y: -0.05142811}
+  m_Offset: {x: -0.002350688, y: 0.082272634}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.25, y: 1.25}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.9563326, y: 1.3245025}
+  m_Size: {x: 1.0611169, y: 0.56748104}
   m_EdgeRadius: 0
---- !u!114 &7887215541740292448
+--- !u!114 &5236896937607921620
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -121,23 +148,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 1109480781222891229}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6b2efb2226c24c739912e6f7de593b41, type: 3}
+  m_Script: {fileID: 11500000, guid: bd18e99da60ee9a44b50fd34b8b18fb4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &-3754631054435307852
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1109480781222891229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 25f19adc479e4d83862f7a07a130acd5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  chefCost: 40
-  rangeCost: 0
+  damageIncrease: 1
+  speedIncrease: 1
+  rangeIncrease: 1
 --- !u!1 &4281193363392056481
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Chef/AbilityBuff.cs
+++ b/Assets/Scripts/Chef/AbilityBuff.cs
@@ -25,28 +25,27 @@ public class AbilityBuff : MonoBehaviour
 
     void Update()
     {
+        // Get all objects within range
         colliders = Physics2D.OverlapCircleAll(transform.position, range);
-        if (colliders != null)
-        {
-            foreach (Collider2D collider in colliders)
-            {
-                GameObject gameObject = collider.gameObject;
-                if (gameObject.CompareTag("HeadChef"))
-                {
-                    Buff buff = gameObject.GetComponent<Buff>();
-                    if (buff == null)
-                    {
-                        gameObject.AddComponent<Buff>();
-                    }
 
-                    buff = gameObject.GetComponent<Buff>();
-                    buff.damageIncrease = ATK;
-                    buff.speedIncrease = ATKSpeed;
-                    buff.rangeIncrease = rangeIncrease;
-                }
-            }
+        Debug.Log("--------------------");
+
+        foreach (Collider2D collider in colliders)
+        {
+            GameObject gameObject = collider.gameObject;        // Get game object
+            Buff buff = gameObject.GetComponent<Buff>();        // Get its "buff" object
+
+            Debug.Log("Found " + gameObject.name);
+
+            // If it has no "buff" object, it isn't a chef
+            if (buff == null){ continue; }
+
+            // If it has a "buff" object, set its stats
+            buff.damageIncrease = ATK;
+            buff.speedIncrease = ATKSpeed;
+            buff.rangeIncrease = rangeIncrease;
+            Debug.Log("Set buff object's stats");
         }
     }
-
 
 }

--- a/Assets/Scripts/Chef/AbilityProjectile.cs
+++ b/Assets/Scripts/Chef/AbilityProjectile.cs
@@ -92,12 +92,15 @@ namespace Chef
         private void SpawnProjectile()
         {
             GameObject p = Instantiate(Projectile, transform.position, transform.rotation);
-            DamageFactor df = this.GetComponent<DamageFactor>();
-            Buff bf = this.GetComponent<Buff>();
-            if (bf != null)
+            DamageFactor df = p.GetComponent<DamageFactor>();
+            Buff buff = GetComponent<Buff>();
+            if (buff != null)
             {
-                p.GetComponent<DamageFactor>().damage = df.damage * bf.damageIncrease;
-                p.GetComponent<ProjectileMover>().projectileSpeed = originalSpeed * bf.speedIncrease;
+                p.GetComponent<DamageFactor>().damage = df.damage * buff.damageIncrease;
+                p.GetComponent<ProjectileMover>().projectileSpeed = originalSpeed * buff.speedIncrease;
+            }
+            else{
+                Debug.Log("FAILED TO GET BUFF");
             }
         }
         


### PR DESCRIPTION
Seem to have fixed all the issues with the chef selection being buggy and the buff script working on head chefs. 

- The head chef had a normal box collider (the size of the chef) as well as a large circle collider. The circle collider was getting in the way of selecting other chefs. 
- The buffing script on the head chef was really convoluted and strange? I've refactored and fixed it up a bit. Buffing seems to work perfectly now, and doesn't apply the buff to other head chefs. 

Note: I assume we don't want head chef buffs stacking though (AKA surrounding one normal chef with a bunch of head chefs to make it really overpowered). Atm it works so that only one head chef buff can be active on a normal chef at once. 